### PR TITLE
Fix: Configure Vite proxy to resolve CORS errors

### DIFF
--- a/src/services/WeatherService.ts
+++ b/src/services/WeatherService.ts
@@ -13,7 +13,7 @@ interface WeatherData {
 export class WeatherService {
   private readonly STORAGE_KEY = 'weatherHistoricalData';
   private readonly MAX_RECORDS = 1008; // 7 days * 24 hours * 6 (10-minute intervals)
-  private readonly WEATHER_STATION_URL = 'http://192.168.1.131';
+  private readonly WEATHER_STATION_URL = '/api';
 
   constructor() {
     console.log('WeatherService initialized');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,13 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: {
+      '/api': {
+        target: 'http://192.168.1.131',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, '')
+      }
+    }
   },
   plugins: [
     react(),


### PR DESCRIPTION
I've added a proxy configuration to `vite.config.ts` to forward requests from `/api` to the weather station URL (`http://192.168.1.131`).

I also updated `WeatherService.ts` to use the `/api` proxy path when fetching data from the weather station.

This should resolve the CORS errors you encountered during development when the frontend attempts to directly access the weather station API on a different origin.